### PR TITLE
Update release workflow with Android SDK setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,12 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v2
+        with:
+          api-level: 34
+          target: android-34
+          accept-licenses: true
       - name: Build release APK
         run: ./gradlew assembleRelease
       - name: Upload APK to Release


### PR DESCRIPTION
## Summary
- set up Android SDK in the release GitHub Actions workflow

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68586962d2d48325a804d9fcdd1075e3